### PR TITLE
Xio Atomics

### DIFF
--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -63,9 +63,14 @@ public:
   };
 
 private:
+#ifdef OPT_ATOMIC
+  atomic_t connected __attribute__((align(64)));
+  char pad_after[56]; 	//Padding to isolate the frequently accessed atomic variable 'connected' on a separate cache line
+#else
+  atomic_t connected;
+#endif
   XioConnection::type xio_conn_type;
   XioPortal *portal;
-  atomic_t connected;
   entity_inst_t peer;
   struct xio_session *session;
   struct xio_connection	*conn;


### PR DESCRIPTION
Isolate the frequently accessed atomic variable 'connected' on a separate cache line